### PR TITLE
Changed export method to var

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,7 @@ let prepare_lang = function(lang_name) {
 module.exports = function(env) {
     config.langs = env && env.langs ? env.langs.split(',') : undefined;
     config.optimize = env && env.optimize;
-    config.libraryTarget = (env && env.libraryTarget) || 'window';
+    config.libraryTarget = (env && env.libraryTarget) || 'var';
 
     return new Promise(function(resolve, reject) {
         fs.readdir(config.lang_configs_path, function(err, files) {


### PR DESCRIPTION
This is important for a clean handoff to the web worker in the UI.
https://webpack.github.io/docs/configuration.html#output-librarytarget