### PR TITLE
Standardized library name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ let prepare_lang = async function(filename) {
             'libraryTarget': libraryTarget,
 
             // When libraryTarget is "window" or "var", the window key or variable name will be this value
-            'library': 'Codesplain_parse_' + lang_name,
+            'library': 'CodesplainParser',
         },
     };
 };


### PR DESCRIPTION
## Description
Changes the exported library name to be `CodesplainParser` across all parsers.

## Motivation and Context
This is necessary for the UI to know which global variable the parser is exported to at all times. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
---
Note, this should be merged concurrently with https://github.com/maryvilledev/codesplainUI/pull/344.