### PR TITLE
Refactor public/index.html to get parser from correct location

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -153,7 +153,7 @@
     let code_el = document.getElementById('code');
     let formatted_el = document.getElementById('formatted');
     code_el.onkeyup = code_el.onchange = function() {
-        let parser = module.exports;
+        let parser = window['CodesplainParser'];
         if (typeof parser !== 'function') {return;}
 
         let code = code_el.value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Parser is obtained from the correct location

## Motivation and Context
The parser was being obtained from `modules.export`, which is the incorrect location.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
