### PR TITLE
Collapsed the `arguments` Rule in Python3

### DIFF
--- a/language_configs/python3.rules.js
+++ b/language_configs/python3.rules.js
@@ -79,7 +79,7 @@ module.exports = {
     'dictorsetmaker': {},
     'classdef': {},
     'arglist': {},
-    'argument': {},
+    'argument': {'collapse': true},
     'comp_iter': {'collapse': true},
     'comp_for': {},
     'comp_if': {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the `collapse` tree matcher to the `arguments` rule in python3 language config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/maryvilledev/codesplainUI/issues/360. This PR will cause arguments to have "higher precedence" than "expressions" in the UI.
