### PR TITLE
Updated publish script to build & push all languages

### DIFF
--- a/publish
+++ b/publish
@@ -26,23 +26,18 @@ fi
 
 rm -rf $CACHE_DIR/treematcher/
 
-# In the future we want to iterate over all language configs:
-# for lang_config in $LANG_CONFIGS_DIR/*.compile.js; do
+# Build and push all parsers to S3 buckets:
+for lang_config in $LANG_CONFIGS_DIR/*.compile.js; do
+  PARSELANG="$(basename $lang_config .compile.js)"
+  printf "Building and publishing $PARSELANG parser\n"
 
-# But for now just do python3:
-lang_config="$LANG_CONFIGS_DIR/python3.js"
+  rm -rf "$CACHE_DIR/$PARSELANG/"
+  ./make --lang $PARSELANG --debug >/dev/null
+  ./make --lang $PARSELANG --minify >/dev/null
 
-PARSELANG="$(basename $lang_config .js)"
-
-rm -rf "$CACHE_DIR/$PARSELANG/"
-./make -d
-./make -m
-
-
-aws s3 cp $OUTPUT_DIR/$PARSELANG.min.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.min.js
-aws s3 cp $OUTPUT_DIR/$PARSELANG.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.js
-aws s3 cp $MAPPINGS_DIR/$PARSELANG.csv s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.csv
+  aws s3 cp $OUTPUT_DIR/$PARSELANG.min.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.min.js
+  aws s3 cp $OUTPUT_DIR/$PARSELANG.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.js
+  aws s3 cp $MAPPINGS_DIR/$PARSELANG.csv s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.csv
+done
 
 exit
-
-# done

--- a/publish
+++ b/publish
@@ -32,8 +32,8 @@ for lang_config in $LANG_CONFIGS_DIR/*.compile.js; do
   printf "Building and publishing $PARSELANG parser\n"
 
   rm -rf "$CACHE_DIR/$PARSELANG/"
-  ./make --lang $PARSELANG --debug >/dev/null
-  ./make --lang $PARSELANG --minify >/dev/null
+  ./make --lang $PARSELANG --debug
+  ./make --lang $PARSELANG --minify
 
   aws s3 cp $OUTPUT_DIR/$PARSELANG.min.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.min.js
   aws s3 cp $OUTPUT_DIR/$PARSELANG.js s3://codesplain-parsers/$PARSELANG/$VERSION_TAG/$PARSELANG.js


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated `publish` to loop through all files with a `.compile.js` extension in the `language_configs` directory, compile their parsers, and push them to S3. This way all languages' parsers will be published, rather than just `python3`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #62. Prior to this PR, only the python parser was published.
