### PR TITLE
Add Tree Matcher Types to CSVs

### DIFF
--- a/__tests__/mappings.js
+++ b/__tests__/mappings.js
@@ -2,22 +2,29 @@ const fs = require('fs');
 
 describe('mappings', () => {
   fs.readdirSync('./language_configs/')
-    .filter((name) => name.split('.')[1] === 'rules' )
-    .forEach((file) => {
-      const csvFileName = `${file.split('.')[0]}.csv`;
+    // Gather set of all langs in "language_configs"
+    .reduce((langs, name) => langs.add(name.split('.')[0]), new Set())
+    .forEach(lang => {
+      const csvFileName = `${lang}.csv`
       describe(csvFileName, () => {
         const encoding = { encoding: 'utf-8' };
         const csv = fs.readFileSync(`./mappings/${csvFileName}`, encoding)
           .split('\n')   // Make array of lines
           .slice(1, -1); // Cut off the header and newline
-        it('should have a definition for all rules', () => {
+        it(`should have a definition for all rules`, () => {
           // Create a sorted array of tokens in the csv
-          const tokens = csv.map((line) => line.split(',')[0])
+          const tokens = csv.map(line => line.split(',')[0])
             .sort((a, b) => a.localeCompare(b));
 
-          // Now create sorted array of rules in the config
-          // file, and compare the two
-          Object.keys(require(`../language_configs/${file}`))
+          // Extract types from tree_matcher_specs.js file for this lang
+          const treeMatcherTypes = require(
+            `../language_configs/${lang}.tree_matcher_specs.js`
+          ).map(spec => spec.type);
+
+          // Now create a sorted array of rules in the config files, and
+          // the tree matcher specs file, then compare the two
+          Object.keys(require(`../language_configs/${lang}.rules.js`))
+            .concat(treeMatcherTypes)
             .sort((a, b) => a.localeCompare(b))
             .forEach((rule, i) => expect(rule).toEqual(tokens[i]));
         });

--- a/language_configs/python3.tree_matcher_specs.js
+++ b/language_configs/python3.tree_matcher_specs.js
@@ -2,51 +2,57 @@ module.exports = [
     {
         // The pattern specifies which nodes to match.
         // When a node is matched, actor will be executed.
-        'pattern': 'for_stmt [.FOR, /.NAME:iter, .IN, /trailed_atom [/.NAME="range", trailer\
+        pattern: 'for_stmt [.FOR, /.NAME:iter, .IN, /trailed_atom [/.NAME="range", trailer\
             [.OPEN_PAREN, arglist [/.DECIMAL_INTEGER:begin, .COMMA,\
             /.DECIMAL_INTEGER:end], .CLOSE_PAREN]], .COLON, suite]',
 
         // This is not currently used and will be used to optimize the javascript matching function in the future.
-        'profile_data': {
+        profile_data: {
             '0': [1,4],
             '0a0': [2,6],
             '0a0b1': [3,6],
         },
+
+        // The string that will be pushed onto the node's tags array
+        type: 'for_range',
 
         // The actor will be run when a node matches.
         // The node that was matched will be available as the root variable.
         // Variables set by the pattern (:iter, :begin, :end) will also be available.
         'actor': function() {
             root.tags.push({
-                'type': 'for_range',
+                'type': this.type,
                 'iter': iter.text,
                 'begin': parseInt(begin.text),
                 'end': parseInt(end.text),
             });
         },
     }, {
-        'pattern': 'trailed_atom [/.NAME:name, trailer [.OPEN_PAREN, arglist:args, .CLOSE_PAREN]]',
-        'actor': function() {
+        pattern: 'trailed_atom [/.NAME:name, trailer [.OPEN_PAREN, arglist:args, .CLOSE_PAREN]]',
+        type: 'function_call',
+        actor: function() {
             console.log(name.text, args.children);
             root.tags.push({
-                'type': 'function_call',
+                'type': this.type,
                 'name': name.text,
                 'args': args.children,
             });
         },
     }, {
-        'pattern': 'atom .TRUE|.FALSE',
-        'actor': function() {
+        pattern: 'atom .TRUE|.FALSE',
+        type: 'boolean',
+        actor: function() {
             root.tags.push({
-                'type': 'boolean',
+                'type': this.type,
             });
         },
     }, {
-        'pattern': 'factor [.MINUS, /number]',
-        'actor': function() {
+        pattern: 'factor [.MINUS, /number]',
+        type: 'negative_number',
+        actor: function() {
             console.log(root);
             root.tags.push({
-                'type': 'negative_number',
+                'type': this.type,
             });
         },
     },

--- a/mappings/python3.csv
+++ b/mappings/python3.csv
@@ -181,3 +181,7 @@ integer,1,Integers,#ABF7C6
 .UNKNOWN_CHAR,0,,
 .INDENT,0,,
 .DEDENT,0,,
+boolean,1,Boolean,#FFCCFF
+for_range,1,For Range Loop,#99CCFF
+function_call,1,Function Call,#DB70B8
+negative_number,1,Negative Number,#33CC33


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the tree matcher types (they currently only exist for Python 3) to the rule CSV files. The CSV tests have been updated to check that the rule CSV files contain the tree matcher types. Finally, the `python3.tree_matcher_specs.js` file has been updated to make each spec's type accessible outside of its `actor` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #56. This change is needed in order for the frontend to make use of the tree matcher types.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.