### PR TITLE
Fixed error callback end being NaN

### DIFF
--- a/app/error_listener.js
+++ b/app/error_listener.js
@@ -13,7 +13,7 @@ ErrorListener.prototype.syntaxError = function(recognizer, offendingSymbol, line
     this.callback({
         'type': 'syntaxError',
         'begin': offendingSymbol.start,
-        'end': offendingSymbol.end + 1,
+        'end': offendingSymbol.stop + 1,
         'msg': msg,
     });
 };


### PR DESCRIPTION
## Description
Changed syntaxError callback in ErrorListener. The object's end property needs to read from offendingSymbol's stop property, not it's end property (which doesn't exist).

## Motivation and Context
Fixes #70 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I will add tests
- [x] All new and existing tests passed.
