### PR TITLE
Re-reapply add C, Clojure, Java (not java8), and Lua #90

### DIFF
--- a/publish
+++ b/publish
@@ -14,7 +14,7 @@ set -e
 # Config begin
 LANG_CONFIGS_DIR=language_configs/
 CACHE_DIR=_cache/
-OUTPUT_DIR=public/langs
+OUTPUT_DIR=build/parsers
 MAPPINGS_DIR="mappings"
 PUSH_ENV="$1"
 VERSION_TAG="$2"


### PR DESCRIPTION
The publish script was reading parsers from the old location. Now reads from `build/parsers/`

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
