### PR TITLE
Re-minify the parser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,24 @@ const prepare_lang = async function(filename) {
         // Tell webpack that fs will be external so it doesn't complain.
         'externals': ['fs'],
 
+        'plugins': [
+            // Run the Google Closure Compiler if env.optimize is set
+            optimize ? new ClosureCompilerPlugin({
+                'compiler': {
+                    'language_in': 'ECMASCRIPT6',
+                    'language_out': 'ECMASCRIPT5',
+                    'compilation_level': 'SIMPLE_OPTIMIZATIONS',
+                    /*
+                    There is a higher compilation level, ADVANCED_OPTIMIZATIONS.
+                    Unfortunately, it requires property access by string or key to be consistent.
+                    For example, obj.abc = 123; alert(obj['abc']); doesn't work.
+                    Antlr does not follow this principle, so as far as I can see, we won't be able to use this level.
+                    */
+                },
+                'concurrency': 10,
+            }) : undefined,
+        ].filter(Boolean),
+
         'output': {
             // The output filename
             'filename': lang_name + (optimize ? '.min.js' : '.js'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert "Removed Google Closure compiler because it's failing"
This reverts commit 4594e0e63893e0caff14ccad7c254f9125be1997.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #95. We are unable to make use of the other parsers, so unminifying
the python parser does not benefit us. It slows down load speeds.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.